### PR TITLE
Add permissions to plugin settings

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -49,12 +49,10 @@ class Plugin extends PluginBase
      */
     public function registerPermissions()
     {
-        return []; // Remove this line to activate
-
         return [
-            'responsiv.currency.some_permission' => [
+            'responsiv.currency.access_settings' => [
                 'tab'   => 'Currency',
-                'label' => 'Some permission'
+                'label' => 'Manage currency settings'
             ]
         ];
     }
@@ -68,7 +66,8 @@ class Plugin extends PluginBase
                 'icon'        => 'icon-usd',
                 'url'         => Backend::url('responsiv/currency/currencies'),
                 'category'    => 'Currency',
-                'order'       => 500
+                'order'       => 500,
+                'permissions' => ['responsiv.currency.access_settings']
             ],
             'converters' => [
                 'label'       => 'Currency converters',
@@ -76,7 +75,8 @@ class Plugin extends PluginBase
                 'icon'        => 'icon-calculator',
                 'url'         => Backend::url('responsiv/currency/converters'),
                 'category'    => 'Currency',
-                'order'       => 510
+                'order'       => 510,
+                'permissions' => ['responsiv.currency.access_settings']
             ]
         ];
     }


### PR DESCRIPTION
At the moment, the settings of this plugin are viewable and editable to all administrators. Accidental editing / deleting of a currency can cause major issues on a page that has implemented the plugin, so safeguarding the settings is a good idea.