### PR TITLE
Do not cast null to "0,00"

### DIFF
--- a/formwidgets/Currency.php
+++ b/formwidgets/Currency.php
@@ -66,8 +66,9 @@ class Currency extends FormWidgetBase
     public function getLoadValue()
     {
         $currencyObj = CurrencyModel::getPrimary();
+        $value = parent::getLoadValue();
 
-        return number_format(parent::getLoadValue(), 2, $currencyObj->decimal_point, "");
+        return !is_null($value) ? number_format($value, 2, $currencyObj->decimal_point, "") : null;
     }
 
     /**


### PR DESCRIPTION
Currently, null-values are also trated as numbers and thus formated as zero (0,00).
This adds correct null handling.