### PR TITLE
Fix wrong long format

### DIFF
--- a/helpers/Currency.php
+++ b/helpers/Currency.php
@@ -53,7 +53,7 @@ class Currency
             : number_format($result, $decimals);
 
         if ($format == 'long') {
-            $result .= ' ' . ($toCurrency ?: $this->primaryCode());
+            $result .= ' ' . ($currencyCode ?: $this->primaryCode());
         }
 
         return $result;


### PR DESCRIPTION
This fixes long format when using the ``in`` option. Without this change the long format uses primary currency instead of the provided one.

```
{{ 123.56 | currency({'in': 'CAD', 'format' : 'long'}) }}
```