### PR TITLE
Added cache clearing for attributes in the currency model

### DIFF
--- a/models/Currency.php
+++ b/models/Currency.php
@@ -223,5 +223,10 @@ class Currency extends Model
     {
         Cache::forget('responsiv.currency.currencies');
         Cache::forget('responsiv.currency.primaryCurrency');
+
+        static::$cacheByCode = [];
+        static::$cacheListEnabled = null;
+        static::$cacheListAvailable = null;
+        static::$primaryCurrency = null;
     }
 }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -10,3 +10,4 @@ v1.0.4: Improvements to currency formatting parameters.
 v1.0.5: Added Italian translation.
 v1.0.6: Fixes bug in Currency form widget casting null to 0.00
 v1.0.7: Fixes compatibility with October CMS v3
+v1.0.8: Fixes cache clearing, clearing static attributes on the model


### PR DESCRIPTION
Fix needed for unit tests.
If the attributes are not cleared, the values ​​from the previous test are stored there.