### PR TITLE
Update translation in de.json

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -13,7 +13,7 @@
   "Successfully disabled those currencies.": "Diese Währungen wurden erfolgreich deaktiviert.",
   "Enable or Disable Currencies": "Währungen aktivieren oder deaktivieren",
   "Currencies selected: :amount": "Ausgewählte Währungen: :Betrag",
-  "Enabled": "Ermöglicht",
+  "Enabled": "Aktiviert",
   "Example": "Beispiel",
   "Formatting": "Formatierung",
   "Symbol": "Symbol",


### PR DESCRIPTION
The German translation for "enabled" in this plugin is wrong. This PR fixes this. 

Also, it looks like the translations from this plugin appear in the Tailor UI as soon as it is installed. This seems to be wrong. Are the translations maybe not properly "namespaced"?

![image](https://github.com/user-attachments/assets/392c9d1b-fda3-474e-8bbd-161353f04cda)
